### PR TITLE
Cylon AST 1.0.0

### DIFF
--- a/information/ast/cylon_ast.md
+++ b/information/ast/cylon_ast.md
@@ -9,7 +9,7 @@
 > `Pyry#6210`  
 > `rad dude broham#2970`  
 
-**Version 0.3.0**
+**Version 1.0.0**
 
 To allow for interoperability between community yolol tools, we've designed the Cylon Yolol AST spec to provide a specification for what an abstract syntax tree (AST) of yolol should look like. This specification is something we hope all community yolol tools will follow, so that we can have all of our tools work together and make more awesome things than we could make alone.
 


### PR DESCRIPTION
Updated version field of Cylon AST to `1.0.0`. The spec seems pretty stable and I would like to actually _use_ the version field semantically, which is kind of challenging below `1.0.0`!