### PR TITLE
UnaryOp Backwards Compatible

### DIFF
--- a/information/ast/cylon_ast.md
+++ b/information/ast/cylon_ast.md
@@ -9,7 +9,7 @@
 > `Pyry#6210`  
 > `rad dude broham#2970`  
 
-**Version 0.3.0**
+**Version 1.1.0**
 
 To allow for interoperability between community yolol tools, we've designed the Cylon Yolol AST spec to provide a specification for what an abstract syntax tree (AST) of yolol should look like. This specification is something we hope all community yolol tools will follow, so that we can have all of our tools work together and make more awesome things than we could make alone.
 
@@ -113,8 +113,11 @@ A binary operation in yolol. The `operator` key is a string which contains the t
 
 ### `expression::unary_op`
 **Required keys:** `operator: String`, `operand: Expression`
+**Optional keys:** `name: string`
 
 A unary operation in yolol. The `operator` key is a string which contains the textual representation (`-` for example) of the operator being applied. Due to the prefix/postfix operators being the same textually, they have the special representation of `++a` and `a++`, to use prefix/postfix increment as an example. `operand` contains the expression that evaluates to the value that the operator is applied to.
+
+The increment/decrement operators do not apply to values and instead operate directly on variables. If the `operator` field is `a++`, `++a`, `a--` or `--a` then the name field should be set to the name of the variable being modified.
 
 ### `expression::number`
 **Required keys:** `num: String`

--- a/information/ast/cylon_ast.md
+++ b/information/ast/cylon_ast.md
@@ -113,7 +113,7 @@ A binary operation in yolol. The `operator` key is a string which contains the t
 
 ### `expression::unary_op`
 **Required keys:** `operator: String`, `operand: Expression`
-**Optional keys:** `name: string`
+**Optional keys:** `name: expression::identifier`
 
 A unary operation in yolol. The `operator` key is a string which contains the textual representation (`-` for example) of the operator being applied. Due to the prefix/postfix operators being the same textually, they have the special representation of `++a` and `a++`, to use prefix/postfix increment as an example. `operand` contains the expression that evaluates to the value that the operator is applied to.
 


### PR DESCRIPTION
This proposal changes the unary op node type to include a `name` field when the operator type is increment or decrement. This is a backwards compatible change (the expression is still required, so existing parsers can completely ignore the new field).

parsers which use the new field instead are simplifed by not having to handle certain types of erroneous programs which cannot be represented by this new field (e.g. `++(a*b)`).

See #38 for breaking change version.