### PR TITLE
UnaryOp Breaking Change

### DIFF
--- a/information/ast/cylon_ast.md
+++ b/information/ast/cylon_ast.md
@@ -114,7 +114,12 @@ A binary operation in yolol. The `operator` key is a string which contains the t
 ### `expression::unary_op`
 **Required keys:** `operator: String`, `operand: Expression`
 
-A unary operation in yolol. The `operator` key is a string which contains the textual representation (`-` for example) of the operator being applied. Due to the prefix/postfix operators being the same textually, they have the special representation of `++a` and `a++`, to use prefix/postfix increment as an example. `operand` contains the expression that evaluates to the value that the operator is applied to.
+A unary operation in yolol. The `operator` key is a string which contains the textual representation (`-` for example) of the operator being applied. `operand` contains the expression that evaluates to the value that the operator is applied to.
+
+### `expression::modify_op`
+**Required keys:** `operator: String`, `name: String`
+
+A modification operation in yolol (i.e. increment of decrement). The operator field contains either `++a`, `a++`, `--a` or `a--`. The name field specifies which variable is being modified.
 
 ### `expression::number`
 **Required keys:** `num: String`

--- a/information/ast/cylon_ast.md
+++ b/information/ast/cylon_ast.md
@@ -117,7 +117,7 @@ A binary operation in yolol. The `operator` key is a string which contains the t
 A unary operation in yolol. The `operator` key is a string which contains the textual representation (`-` for example) of the operator being applied. `operand` contains the expression that evaluates to the value that the operator is applied to.
 
 ### `expression::modify_op`
-**Required keys:** `operator: String`, `name: String`
+**Required keys:** `operator: String`, `name: expression::identifier`
 
 A modification operation in yolol (i.e. increment of decrement). The operator field contains either `pre-increment`, `post-increment`, `pre-decrement` or `post-decrement`. The name field specifies which variable is being modified.
 

--- a/information/ast/cylon_ast.md
+++ b/information/ast/cylon_ast.md
@@ -9,7 +9,7 @@
 > `Pyry#6210`  
 > `rad dude broham#2970`  
 
-**Version 0.3.0**
+**Version 1.1.0**
 
 To allow for interoperability between community yolol tools, we've designed the Cylon Yolol AST spec to provide a specification for what an abstract syntax tree (AST) of yolol should look like. This specification is something we hope all community yolol tools will follow, so that we can have all of our tools work together and make more awesome things than we could make alone.
 

--- a/information/ast/cylon_ast.md
+++ b/information/ast/cylon_ast.md
@@ -119,7 +119,7 @@ A unary operation in yolol. The `operator` key is a string which contains the te
 ### `expression::modify_op`
 **Required keys:** `operator: String`, `name: String`
 
-A modification operation in yolol (i.e. increment of decrement). The operator field contains either `++a`, `a++`, `--a` or `a--`. The name field specifies which variable is being modified.
+A modification operation in yolol (i.e. increment of decrement). The operator field contains either `pre-increment`, `post-increment`, `pre-decrement` or `post-decrement`. The name field specifies which variable is being modified.
 
 ### `expression::number`
 **Required keys:** `num: String`

--- a/information/ast/cylon_ast.md
+++ b/information/ast/cylon_ast.md
@@ -9,7 +9,7 @@
 > `Pyry#6210`  
 > `rad dude broham#2970`  
 
-**Version 1.1.0**
+**Version 2.0.0**
 
 To allow for interoperability between community yolol tools, we've designed the Cylon Yolol AST spec to provide a specification for what an abstract syntax tree (AST) of yolol should look like. This specification is something we hope all community yolol tools will follow, so that we can have all of our tools work together and make more awesome things than we could make alone.
 


### PR DESCRIPTION
This proposal add a new node type which moves the increment and decrement operators out of the unary op node and into a new node type. This simplifies parsing of the AST by removing the need to handle errenous programs (e.g. `++(a*b)`) which can no longer be represented by the AST.

See #37 for backcompat version.