### PR TITLE
Fix for inconsistency in variable naming in Function section of MultiChipModel.md

### DIFF
--- a/thinktank/MultiChipModels.md
+++ b/thinktank/MultiChipModels.md
@@ -20,7 +20,7 @@ result = :r1                                          // Fetch result
 ```
 // Chip 2
 if :call == 0 then goto 1 end // Wait for function to be called
-:result = :p1 + :p2 + :p3     // Execute function body; this can be as many lines as necessary
+:r1 = :p1 + :p2 + :p3     // Execute function body; this can be as many lines as necessary
 :call = 0 goto 1              // Indicate that the function is complete
 ```
 


### PR DESCRIPTION
Chip 1's result variable was labeled as :r1, Chip 2 was :result