### PR TITLE
Fixed typo in line 47

### DIFF
--- a/information/experimental-results.md
+++ b/information/experimental-results.md
@@ -44,7 +44,7 @@ nota=0 :out=not a         -> 1
 a=3 :out=abs1+a           -> 3
 a=3 :out=abs 1+a          -> 4
 x=0 :out=notx             -> 1 
-x=0 :out=ifa              -> 0
+x=0 :out=ifx              -> 0
 x=0 :out=xor              -> 0
 orx=0 :out=x              -> 0
 ```


### PR DESCRIPTION
The original statement, "x=0 :out=ifa" makes no sense as the :out assignment makes no reference to x.